### PR TITLE
Add fang special attack

### DIFF
--- a/lib/dps/Accuracy.js
+++ b/lib/dps/Accuracy.js
@@ -18,10 +18,33 @@ export class Accuracy {
     }
 
     compareRolls(atk, def) {
+        let acc
+        
         if (atk > def) {
-            return Math.max(0, Math.min(1, 1 - (def + 2) / (2 * (atk + 1))))
+            acc = Math.max(0, Math.min(1, 1 - (def + 2) / (2 * (atk + 1))))
         } else {
-            return Math.max(0, Math.min(1, atk / (2 * (def + 1))))
+            acc = Math.max(0, Math.min(1, atk / (2 * (def + 1))))
+        }
+
+        if (this.flags.includes("Osmumten's fang")) {
+            if (this.flags.includes("Tombs of Amascut")) {
+                acc = acc + (1 - acc) * acc
+            } else {
+                acc = this.compareFangRolls(atk, def)
+            }
+        }
+
+        return acc
+    }
+
+    compareFangRolls(atk, def) {
+        // Formula to use outside of toa
+        let clamp = (n) => Math.max(0, Math.min(1, n))
+
+        if (atk > def) {
+            return clamp(1 - (def + 2)*(2*def+3)/(atk+1)/(atk+1)/6)
+        } else {
+            return clamp(atk * (4 * atk + 5) / 6 / (atk + 1) / (def + 1))
         }
     }
 
@@ -99,7 +122,6 @@ export class Accuracy {
         if (this.flags.includes("Inquisitor's armour set")) {
             inqBonus = 1025
         }
-
         playerRoll = Math.floor(playerRoll * inqBonus / 1000)
 
 

--- a/lib/dps/Dps.js
+++ b/lib/dps/Dps.js
@@ -96,6 +96,8 @@ export class Dps {
                 return "Smash";
             case "Ancient godsword":
                 return "Blood Sacrifice"
+            case "Osmumten's fang":
+                return "Eviscerate"
         }
         if (weapon.includes("Toxic blowpipe")) {
             return "Toxic Siphon"
@@ -266,6 +268,9 @@ export class Dps {
 
         if (this.calcs.specName !== null) {
             this.calcs = specialAttacks.applySpec(this.calcs.specName)
+        } else if (this.calcs.flags.includes("Osmumten's fang")) {
+            // Only do normal fang calcs when not a spec to avoid overriding
+            this.calcs = specs.fang();
         }
 
 
@@ -273,9 +278,6 @@ export class Dps {
             this.calcs = specs.scythe()
         } else if (this.calcs.flags.includes("Dark bow")) {
             this.calcs = specs.darkbow();
-        }
-        else if (this.calcs.flags.includes("Osmumten's fang")){
-            this.calcs = specs.fang();
         }
 
 
@@ -335,8 +337,6 @@ export class Dps {
         if (this.calcs.flags.includes("Verzik P1")) {
             this.calcs = specs.verzik();
         }
-
-
     }
 
     output() {

--- a/lib/dps/SpecialAttacks.js
+++ b/lib/dps/SpecialAttacks.js
@@ -39,6 +39,8 @@ export class SpecialAttacks {
                 return this.dwh();
             case "Blood Sacrifice":
                 return this.zgs();
+            case "Eviscerate":
+                return this.fang()
         }
         return this.calcs
     }
@@ -477,6 +479,28 @@ export class SpecialAttacks {
         dps.eDefReduction += eDefReduction
         dps.maxList = [max]
         dps.maxHit = max
+        return dps;
+    }
+
+    fang() {
+        // Allows for fang's true max hit and 50% increase to accuracy
+        const dps = this.calcs
+        const accCalc = new Accuracy(this.state, this.calcs)
+        let acc = accCalc.compareRolls(dps.playerRoll * 1.5, dps.npcRoll)
+
+        let fangHitStore = new HitFreqStore();
+        fangHitStore.store([0], (1 - acc))
+        
+        const max = dps.maxHit
+        const min = Math.trunc(max * 0.15)
+
+        for (let dmg = min; dmg <= max; dmg++) {
+            fangHitStore.store([dmg], acc / (max + 1))
+        }
+
+        dps.hitStore = fangHitStore
+        dps.accuracy = acc
+        dps.rawAcc = acc
         return dps;
     }
 }

--- a/lib/dps/SpecialWeapons.js
+++ b/lib/dps/SpecialWeapons.js
@@ -1,5 +1,6 @@
 import { HitFreqStore } from "./HitFreqStore.js";
 
+
 function pickaxeToLevel(pickName) {
     switch (pickName) {
         case "3rd age pickaxe":
@@ -627,33 +628,12 @@ export class SpecialWeapons {
     }
 
     fang(){
+        // Apply fang's min and max hit logic
         const dps = this.calcs
+        const acc = dps.accuracy
         const oldMax = dps.maxHit
         const min = Math.trunc(oldMax * 0.15)
         const newMax = oldMax - min
-
-        const accuracyFormula = (atk, def) => {
-            let clamp = (n) => Math.max(0, Math.min(1, n))
-
-            if (atk > def) {
-                return clamp(1 - (def + 2)*(2*def+3)/(atk+1)/(atk+1)/6)
-            } else {
-                return clamp(atk * (4 * atk + 5) / 6 / (atk + 1) / (def + 1))
-            }
-        }
-
-        let acc = dps.accuracy
-        let specAcc = dps.accuracy * 1.5
-
-        if(this.calcs.flags.includes("Tombs of Amascut")){
-            acc = acc + (1 - acc) * acc
-            specAcc = specAcc + (1 - specAcc) * specAcc
-        }
-        else{
-            acc = accuracyFormula(dps.playerRoll, dps.npcRoll)
-            specAcc = accuracyFormula(dps.playerRoll * 1.5, dps.npcRoll)
-        }
-        
 
         let hitStore = new HitFreqStore();
         hitStore.store([0], 1 - acc)
@@ -662,16 +642,9 @@ export class SpecialWeapons {
             hitStore.store([h1], acc / (newMax - min + 1))
         }
 
-        dps.maxHitSpec = oldMax // spec can hit for full damage
-        if(dps.flags.includes("Corporeal beast")){
-            dps.maxHitSpec = Math.trunc(newMax/2)
-        }
-
         dps.hitStore = hitStore
-        dps.rawAcc = acc
-        dps.accuracy = acc
-        dps.specAcc = specAcc
         dps.maxList = [newMax]
+        dps.maxHit = newMax
         return dps
     }
 


### PR DESCRIPTION
This adds the fang's special attack and restructures some logic. I moved the double roll stuff into `Accuracy` so both the regular hit and special attack can use it without duplicating the logic.